### PR TITLE
feat(auth): default to /explore, allow unauthenticated users to explore

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,7 @@ const App = () => {
     return (
         <Router>
             <Routes>
-                <Route path="/" element={<Navigate to="/timeline" replace />} />
+                <Route path="/" element={<Navigate to="/explore" replace />} />
                 <Route path="/login" element={!!user ? <Navigate to="/timeline" replace /> : <LoginPage />} />
                 <Route path="/timeline" element={!!user ? <TimelinePage /> : <Navigate to="/login" replace />} />
                 <Route path="/following" element={!!user ? <FollowingPage /> : <Navigate to="/login" replace />} />

--- a/frontend/src/components/feed/FeedCard.tsx
+++ b/frontend/src/components/feed/FeedCard.tsx
@@ -15,12 +15,28 @@ const FeedCardTitle = ({ feedName, feedUuid }: { feedName: Post['feed_name']; fe
     const navigate = useNavigate()
 
     const unfollowFeed = async (e: Event, feedUuid: string) => {
-        await api.post('/user/unfollow_feed', { feed_uuid: feedUuid })
+        try {
+            await api.post('/user/unfollow_feed', { feed_uuid: feedUuid })
+        } catch (error) {
+            // If the user is not authenticated, redirect to login page
+            if ((error as any).response.status === 401) {
+                window.location.href = '/login'
+            }
+        }
+
         loadUser()
     }
 
     const followFeed = async (e: Event, feedUuid: string) => {
-        await api.post('/user/follow_feed', { feed_uuid: feedUuid })
+        try {
+            await api.post('/user/follow_feed', { feed_uuid: feedUuid })
+        } catch (error) {
+            // If the user is not authenticated, redirect to login page
+            if ((error as any).response.status === 401) {
+                window.location.href = '/login'
+            }
+        }
+
         loadUser()
     }
     return (

--- a/frontend/src/components/new-feed-modal/NewFeedModal.tsx
+++ b/frontend/src/components/new-feed-modal/NewFeedModal.tsx
@@ -25,6 +25,11 @@ const NewFeedModal = () => {
             navigate(`/feed/${response.data.feed_uuid}`)
             // loadPosts()
         } catch (error: any) {
+            // If the user is not authenticated, redirect to login page
+            if ((error as any).response.status === 401) {
+                window.location.href = '/login'
+            }
+
             if (error.response?.data) {
                 const errors = Object.values(error.response.data)
                 notification.error({

--- a/frontend/src/components/post/postLogic.ts
+++ b/frontend/src/components/post/postLogic.ts
@@ -80,17 +80,38 @@ export const postLogic = kea<postLogicType>([
     })),
     listeners(({ actions, props }) => ({
         likePost: async () => {
-            const response = await api.post(`/posts/${props.postUuid}/like`)
+            try {
+                await api.post(`/posts/${props.postUuid}/like`)
+            } catch (error) {
+                // If the user is not authenticated, redirect to login page
+                if ((error as any).response.status === 401) {
+                    window.location.href = '/login'
+                }
+            }
             // reconsider this?
             actions.loadPost()
         },
         unlikePost: async () => {
-            const response = await api.post(`/posts/${props.postUuid}/unlike`)
+            try {
+                await api.post(`/posts/${props.postUuid}/unlike`)
+            } catch (error) {
+                // If the user is not authenticated, redirect to login page
+                if ((error as any).response.status === 401) {
+                    window.location.href = '/login'
+                }
+            }
             // reconsider this?
             actions.loadPost()
         },
         comment: async ({ comment }) => {
-            const response = await api.post(`/post_comments`, { ...comment })
+            try {
+                await api.post(`/post_comments`, { ...comment })
+            } catch (error) {
+                // If the user is not authenticated, redirect to login page
+                if ((error as any).response.status === 401) {
+                    window.location.href = '/login'
+                }
+            }
             actions.loadComments()
             actions.loadPost()
         },

--- a/frontend/src/components/timeline/TimelineHeader.tsx
+++ b/frontend/src/components/timeline/TimelineHeader.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import { Layout, Tooltip, notification } from 'antd'
-import { LogoutOutlined } from '@ant-design/icons'
+import { LogoutOutlined, LoginOutlined } from '@ant-design/icons'
 import { api } from '../../lib/api'
 import { useNavigate } from 'react-router-dom'
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
 import { userLogic } from '../../userLogic'
 
 const { Header } = Layout
@@ -11,6 +11,7 @@ const { Header } = Layout
 const TimelineHeader = () => {
     const navigate = useNavigate()
     const { setUser } = useActions(userLogic)
+    const { user } = useValues(userLogic)
 
     const handleLogout = async (values: any) => {
         try {
@@ -42,13 +43,23 @@ const TimelineHeader = () => {
             <div className="platform-name" onClick={() => navigate('/timeline')} style={{ cursor: 'pointer' }}>
                 recess
             </div>
-            <Tooltip title="Logout">
-                <LogoutOutlined
-                    rotate={180}
-                    onClick={handleLogout}
-                    style={{ fontSize: 20, color: 'rgb(138 169 193)', cursor: 'pointer' }}
-                />
-            </Tooltip>
+            {user ? (
+                <Tooltip title="Logout">
+                    <LogoutOutlined
+                        rotate={180}
+                        onClick={handleLogout}
+                        style={{ fontSize: 20, color: 'rgb(138 169 193)', cursor: 'pointer' }}
+                    />
+                </Tooltip>
+            ) : (
+                <Tooltip title="Login">
+                    <LoginOutlined
+                        rotate={180}
+                        onClick={() => navigate('/login')}
+                        style={{ fontSize: 20, color: 'rgb(138 169 193)', cursor: 'pointer' }}
+                    />
+                </Tooltip>
+            )}
         </Header>
     )
 }

--- a/recess/api/feed.py
+++ b/recess/api/feed.py
@@ -3,36 +3,54 @@ from recess.models import Feed, Post
 import feedparser
 from uuid import uuid4
 from rest_framework.decorators import action
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny
 import requests
 from email.utils import parsedate_to_datetime
 from recess.feed_utils import parse_date, tz_aware_datetime
-    
+
 
 class FeedSerializer(serializers.ModelSerializer):
     class Meta:
         model = Feed
-        fields = ["feed_uuid", "feed_url", "feed_name", "feed_follower_count", "feed_picture_url", "feed_last_updated", "feed_description"]
-        read_only_fields = ["feed_uuid", "feed_name", "feed_follower_count", "feed_picture_url", "feed_last_updated", "feed_description"] 
-
+        fields = [
+            "feed_uuid",
+            "feed_url",
+            "feed_name",
+            "feed_follower_count",
+            "feed_picture_url",
+            "feed_last_updated",
+            "feed_description",
+        ]
+        read_only_fields = [
+            "feed_uuid",
+            "feed_name",
+            "feed_follower_count",
+            "feed_picture_url",
+            "feed_last_updated",
+            "feed_description",
+        ]
 
     def create(self, validated_data):
         feed_uuid = uuid4()
-        rss_feed = feedparser.parse(validated_data['feed_url'])
-        feed_name = rss_feed.feed.title # this needs error handling
-        feed_description = rss_feed.feed.description # this needs error handling
-        feed_picture_url = ''
-        feed_last_publish = tz_aware_datetime(parsedate_to_datetime(rss_feed.feed.updated)) if rss_feed.feed.updated is not None else None
-        
-        if hasattr(rss_feed.feed, 'image') and hasattr(rss_feed.feed.image, 'href'):
-            feed_picture_url = rss_feed.feed.image.href 
-        elif hasattr(rss_feed.feed, 'author') and hasattr(rss_feed.feed.author, 'logo'):
-            feed_picture_url = rss_feed.author.logo 
-        elif hasattr(rss_feed.feed, 'link'):
-            res = requests.get(rss_feed.feed.link + '/favicon.ico')
+        rss_feed = feedparser.parse(validated_data["feed_url"])
+        feed_name = rss_feed.feed.title  # this needs error handling
+        feed_description = rss_feed.feed.description  # this needs error handling
+        feed_picture_url = ""
+        feed_last_publish = (
+            tz_aware_datetime(parsedate_to_datetime(rss_feed.feed.updated))
+            if rss_feed.feed.updated is not None
+            else None
+        )
+
+        if hasattr(rss_feed.feed, "image") and hasattr(rss_feed.feed.image, "href"):
+            feed_picture_url = rss_feed.feed.image.href
+        elif hasattr(rss_feed.feed, "author") and hasattr(rss_feed.feed.author, "logo"):
+            feed_picture_url = rss_feed.author.logo
+        elif hasattr(rss_feed.feed, "link"):
+            res = requests.get(rss_feed.feed.link + "/favicon.ico")
             if res.status_code == 200:
-                feed_picture_url = rss_feed.feed.link + '/favicon.ico'
-        
+                feed_picture_url = rss_feed.feed.link + "/favicon.ico"
+
         feed_data = {
             **validated_data,
             "feed_uuid": feed_uuid,
@@ -41,37 +59,35 @@ class FeedSerializer(serializers.ModelSerializer):
             "feed_picture_url": feed_picture_url,
             "feed_last_publish": feed_last_publish,
         }
-        
+
         res = super().create(feed_data)
-        
+
         for entry in rss_feed.entries:
             post_published_date = parse_date(entry)
-            
+
             # we're currently skipping posts we can't get a date for
             # is this the best approach?
             if post_published_date is None:
                 continue
-  
+
             Post.objects.create(
-                feed = Feed.objects.get(feed_uuid=feed_uuid),
-                post_url = entry['link'],
-                post_name = entry['title'],
-                post_published_date = post_published_date,
-                post_description = entry['summary']
-            ) 
+                feed=Feed.objects.get(feed_uuid=feed_uuid),
+                post_url=entry["link"],
+                post_name=entry["title"],
+                post_published_date=post_published_date,
+                post_description=entry["summary"],
+            )
         return res
-    
-    
+
 
 class FeedViewset(viewsets.ModelViewSet):
     queryset = Feed.objects.all().order_by("feed_uuid")
     serializer_class = FeedSerializer
 
-    def get_permissions(self):
-        return [IsAuthenticated()]
+    permission_classes = [AllowAny]
 
-    @action(detail=False, methods=['get'])
+    @action(detail=False, methods=["get"])
     def trending(self, request):
-        trending_feeds = Feed.objects.order_by('-feed_follower_count')[:5]
+        trending_feeds = Feed.objects.order_by("-feed_follower_count")[:5]
         serializer = self.get_serializer(trending_feeds, many=True)
         return response.Response(serializer.data)

--- a/recess/api/post.py
+++ b/recess/api/post.py
@@ -1,18 +1,22 @@
 import html
 from rest_framework import serializers, viewsets
+from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from recess.models import Post, PostComment
 from rest_framework.decorators import action
 from recess.api.api_utils import get_paginated_queryset
 from recess.settings import DEFAULT_PAGE_SIZE
+from recess.models import User
 
 
-def _add_user_metadata_to_posts(posts, user):
+def _add_user_metadata_to_posts(posts, user: User):
     for post in posts:
-        post["liked_by_user"] = user.posts_liked.filter(post_uuid=post["post_uuid"]).exists()
+        post["liked_by_user"] = user.posts_liked.filter(
+            post_uuid=post["post_uuid"]
+        ).exists()
     return posts
-    
+
 
 class PostSerializer(serializers.ModelSerializer):
     feed_uuid = serializers.SerializerMethodField()
@@ -21,11 +25,37 @@ class PostSerializer(serializers.ModelSerializer):
     post_description = serializers.SerializerMethodField()
     post_name = serializers.SerializerMethodField()
     liked_by_user = serializers.SerializerMethodField()
-    
+
     class Meta:
         model = Post
-        fields = ["post_uuid", "feed", "post_url", "post_name", "post_description", "post_published_date", "feed_uuid", "feed_name", "feed_picture_url", "post_like_count", "post_comment_count", "liked_by_user"]
-        read_only_fields = ["post_uuid", "feed", "post_url", "post_name", "post_description", "post_published_date", "feed_uuid", "feed_name", "feed_picture_url", "post_like_count", "post_comment_count", "liked_by_user"]
+        fields = [
+            "post_uuid",
+            "feed",
+            "post_url",
+            "post_name",
+            "post_description",
+            "post_published_date",
+            "feed_uuid",
+            "feed_name",
+            "feed_picture_url",
+            "post_like_count",
+            "post_comment_count",
+            "liked_by_user",
+        ]
+        read_only_fields = [
+            "post_uuid",
+            "feed",
+            "post_url",
+            "post_name",
+            "post_description",
+            "post_published_date",
+            "feed_uuid",
+            "feed_name",
+            "feed_picture_url",
+            "post_like_count",
+            "post_comment_count",
+            "liked_by_user",
+        ]
 
     def get_feed_uuid(self, obj):
         return obj.feed.feed_uuid
@@ -35,111 +65,145 @@ class PostSerializer(serializers.ModelSerializer):
 
     def get_feed_picture_url(self, obj):
         return obj.feed.feed_picture_url
-    
+
     def get_post_name(self, obj):
         return html.unescape(obj.post_name)
-    
+
     def get_post_description(self, obj):
         return html.unescape(obj.post_description)
-    
+
     def get_liked_by_user(self, obj):
-        user = self.context['request'].user
+        user = self.context["request"].user
+        if user.is_anonymous:
+            return False
         return user.posts_liked.filter(post_uuid=obj.post_uuid).exists()
-    
+
+
 class PostViewset(viewsets.ModelViewSet):
     serializer_class = PostSerializer
 
     def get_permissions(self):
         return [IsAuthenticated()]
-    
+
     def get_queryset(self):
-        feed_uuid = self.request.GET.get('feed_uuid', None)
+        feed_uuid = self.request.GET.get("feed_uuid", None)
         if feed_uuid is not None:
-            return Post.objects.filter(feed__feed_uuid=feed_uuid).order_by("-post_published_date")
+            return Post.objects.filter(feed__feed_uuid=feed_uuid).order_by(
+                "-post_published_date"
+            )
         return Post.objects.all()
-    
+
     def get_serializer_context(self):
         context = super().get_serializer_context()
         context.update({"request": self.request})
         return context
 
-        
-    @action(methods=["GET"], detail=False, permission_classes=[AllowAny()])
-    def explore(self, request, **kwargs):
-        page = int(self.request.GET.get('page', 0))
-        if request.user:
-            queryset = Post.objects.exclude(feed__in=request.user.feeds_following.all()).order_by("-post_published_date")
-        else:
-            queryset = Post.objects.all().order_by("-post_published_date")
-            
-        queryset = get_paginated_queryset(queryset, page)
-
-        serializer = PostSerializer(queryset, many=True, context=self.get_serializer_context())
-        return Response(
-            { 
-             "data": _add_user_metadata_to_posts(serializer.data, request.user), 
-             "count": len(queryset), 
-             "current_page": page, 
-             "next_page": page + 1 if len(queryset) >= DEFAULT_PAGE_SIZE else None  
-            }, 
-            status=200
-        )
-    
     # should this be handled as a query param on the get_queryset method?
     @action(methods=["GET"], detail=False)
     def timeline(self, request, **kwargs):
-        page = int(self.request.GET.get('page', 0))
+        page = int(self.request.GET.get("page", 0))
         if request.user.feeds_following.count() == 0:
             queryset = Post.objects.exclude().order_by("-post_published_date")
         else:
-            queryset = Post.objects.filter(feed__in=request.user.feeds_following.all()).order_by("-post_published_date")
+            queryset = Post.objects.filter(
+                feed__in=request.user.feeds_following.all()
+            ).order_by("-post_published_date")
 
         queryset = get_paginated_queryset(queryset, page)
 
-        serializer = PostSerializer(queryset, many=True, context=self.get_serializer_context())
+        serializer = PostSerializer(
+            queryset, many=True, context=self.get_serializer_context()
+        )
         return Response(
-            { 
-             "data": _add_user_metadata_to_posts(serializer.data, request.user), 
-             "count": len(queryset), 
-             "current_page": page, 
-             "next_page": page + 1 if len(queryset) >= DEFAULT_PAGE_SIZE else None  
-            }, 
-            status=200
-        )    
+            {
+                "data": _add_user_metadata_to_posts(serializer.data, request.user),
+                "count": len(queryset),
+                "current_page": page,
+                "next_page": page + 1 if len(queryset) >= DEFAULT_PAGE_SIZE else None,
+            },
+            status=200,
+        )
 
-        
     @action(methods=["POST"], detail=True)
     def like(self, request, **kwargs):
         post = self.get_object()
 
         # optimize this?
-        if post in request.user.posts_liked.all():  
-            return Response(status=200, data={ "liked": False, "detail": "Post already liked by user" })
-        
+        if post in request.user.posts_liked.all():
+            return Response(
+                status=200,
+                data={"liked": False, "detail": "Post already liked by user"},
+            )
+
         post.post_like_count += 1
         post.save()
-        
+
         request.user.posts_liked.add(post)
         request.user.save()
-                    
-        return Response(status=200, data={ "liked": True, "detail": "" })
-    
+
+        return Response(status=200, data={"liked": True, "detail": ""})
+
     @action(methods=["POST"], detail=True)
     def unlike(self, request, **kwargs):
         post = self.get_object()
 
         # optimize this?
-        if post not in request.user.posts_liked.all():  
-            return Response(status=200, data={ "unliked": False, "detail": "Post already not liked by user" })
-        
+        if post not in request.user.posts_liked.all():
+            return Response(
+                status=200,
+                data={"unliked": False, "detail": "Post already not liked by user"},
+            )
+
         post.post_like_count -= 1
         post.save()
-        
+
         request.user.posts_liked.remove(post)
         request.user.save()
-                    
-        return Response(status=200, data={ "unliked": True, "detail": "" })
-    
+
+        return Response(status=200, data={"unliked": True, "detail": ""})
+
+
+class ExploreView(APIView):
+    """
+    Provides a paginated list of posts from all feeds that the user is not
+    following. If the user is not authenticated, it will return a paginated
+    list of all posts.
+
+    A sepearte view to ensure that we can provide a different permissioning
+    model.
+    """
+
+    permission_classes = [AllowAny]
+
+    def get(self, request, *args, **kwargs):
+        page = int(request.GET.get("page", 0))
+        if request.user.is_authenticated:
+            queryset = Post.objects.exclude(
+                feed__in=request.user.feeds_following.all()
+            ).order_by("-post_published_date")
+        else:
+            queryset = Post.objects.all().order_by("-post_published_date")
+
+        queryset = get_paginated_queryset(queryset, page)
+
+        serializer = PostSerializer(queryset, many=True, context={"request": request})
+
+        if False:
+            data = _add_user_metadata_to_posts(serializer.data, request.user)
+        else:
+            data = serializer.data
+
+        return Response(
+            {
+                "data": data,
+                "count": len(queryset),
+                "current_page": page,
+                "next_page": page + 1 if len(queryset) >= DEFAULT_PAGE_SIZE else None,
+            },
+            status=200,
+        )
+
+
 class PostCommentSerializer(serializers.ModelSerializer):
     comment_username = serializers.SerializerMethodField()
     comment_user_email = serializers.SerializerMethodField()
@@ -147,40 +211,48 @@ class PostCommentSerializer(serializers.ModelSerializer):
     class Meta:
         model = PostComment
         fields = "__all__"
-        read_only_fields = ["comment_uuid", "post", "comment_timestamp", "comment_username", "comment_user_email"]
+        read_only_fields = [
+            "comment_uuid",
+            "post",
+            "comment_timestamp",
+            "comment_username",
+            "comment_user_email",
+        ]
 
     def get_comment_username(self, obj):
         return obj.comment_author.username
-    
+
     def get_comment_user_email(self, obj):
         return obj.comment_author.email
-    
+
+
 class PostCommentViewset(viewsets.ModelViewSet):
     serializer_class = PostCommentSerializer
-
 
     def get_permissions(self):
         return [IsAuthenticated()]
 
     def get_queryset(self):
-        post_uuid = self.request.GET.get('post_uuid', None)
+        post_uuid = self.request.GET.get("post_uuid", None)
         if post_uuid is not None:
-            return PostComment.objects.filter(post__post_uuid=post_uuid).order_by("-comment_timestamp")
+            return PostComment.objects.filter(post__post_uuid=post_uuid).order_by(
+                "-comment_timestamp"
+            )
         return PostComment.objects.all()
 
-    
     def create(self, request, **kwargs):
-        post_uuid = request.data.get('comment_post_uuid')
-        comment_content = request.data.get('comment_content')
+        post_uuid = request.data.get("comment_post_uuid")
+        comment_content = request.data.get("comment_content")
 
         try:
             post = Post.objects.get(post_uuid=post_uuid)
         except Post.DoesNotExist:
             return Response(status=400, data={"detail": "Invalid post UUID"})
 
-        comment = PostComment.objects.create(post=post, comment_author=request.user, comment_content=comment_content)
+        comment = PostComment.objects.create(
+            post=post, comment_author=request.user, comment_content=comment_content
+        )
         post.post_comment_count += 1
         post.save()
         serializer = self.get_serializer(comment)
         return Response(serializer.data, status=201)
-    

--- a/recess/urls.py
+++ b/recess/urls.py
@@ -1,8 +1,7 @@
-
 from django.contrib import admin
 from django.urls import path, re_path
 from .api.feed import FeedViewset
-from .api.post import PostViewset, PostCommentViewset
+from .api.post import ExploreView, PostViewset, PostCommentViewset
 from .api.user import UserViewSet
 from rest_framework_extensions.routers import ExtendedDefaultRouter
 from django.views.generic import TemplateView
@@ -20,17 +19,17 @@ class Router(ExtendedDefaultRouter):
 router = Router()
 router.register(r"api/feed", FeedViewset, basename="feed")
 router.register(r"api/posts", PostViewset, basename="posts")
-router.register(r'api/user', UserViewSet, basename='user')
-router.register(r'api/post_comments', PostCommentViewset, basename='post_comments')
-
+router.register(r"api/user", UserViewSet, basename="user")
+router.register(r"api/post_comments", PostCommentViewset, basename="post_comments")
 
 
 urlpatterns = [
-    path('', TemplateView.as_view(template_name='index.html'), name="app-root"),
-    path('admin/', admin.site.urls),
-    *router.urls
+    path("", TemplateView.as_view(template_name="index.html"), name="app-root"),
+    path("admin/", admin.site.urls),
+    path(r"api/posts/explore", ExploreView.as_view(), name="explore"),
+    *router.urls,
 ] + staticfiles_urlpatterns()
 
-urlpatterns += [re_path(r'.*', TemplateView.as_view(template_name='index.html'), name="app")]
-
-
+urlpatterns += [
+    re_path(r".*", TemplateView.as_view(template_name="index.html"), name="app")
+]


### PR DESCRIPTION
Just a first pass:

 1. allow public for /explore and /trending
 2. redirect users to /login if api hits a 401
 3. add a login button to the header

I've also formatted with black by accident but not sure worth backing that out.